### PR TITLE
Fix chat history dissapearing on reload

### DIFF
--- a/app/static/js/connection.js
+++ b/app/static/js/connection.js
@@ -100,6 +100,8 @@ $(document).ready(() => {
 
         updateUsers();
         apply_layout(await layout);
+        $("#chat-area").empty();
+
         history = await history;
         if (typeof print_history !== "undefined") {
             print_history(history[room.name]);
@@ -121,7 +123,6 @@ $(document).ready(() => {
             case "join":
                 let user = data.user;
                 updateUsers();
-                $("#chat-area").empty();
                 break;
             case "leave":
                 delete users[data.user.id];


### PR DESCRIPTION
Currently, whenever a user reloads the page, every other user in the same chat room loses their chat history and messages.
This pull request fixes this bug by clearing the chat-area only when the current user joins a new room, instead of whenever any user joins the chat room.