### PR TITLE
Event for live typing mode

### DIFF
--- a/app/chat/message.py
+++ b/app/chat/message.py
@@ -32,6 +32,19 @@ def keypress(message):
             emit('stop_typing', {'user': user}, room=room.name)
 
 
+@socketio.on('typed_message')
+def typed_message(payload):
+    current_user_id = current_user.get_id()
+    if not current_user_id:
+        return
+
+    for room in current_user.rooms:
+        user = {
+             'id': current_user_id,
+             'name': current_user.name,
+        }
+        emit('user_message', {'user': user, 'message': payload['msg']}, room=room.name)
+
 @socketio.on('text')
 @login_required
 def message_text(payload):

--- a/app/chat/message.py
+++ b/app/chat/message.py
@@ -34,6 +34,11 @@ def keypress(message):
 
 @socketio.on('typed_message')
 def typed_message(payload):
+    """
+    This function handles live-typing mode. It is called when 'typed_message'
+    event is fired and broadcasts the current message that the user typed to 
+    the room through 'user_message' event.
+    """
     current_user_id = current_user.get_id()
     if not current_user_id:
         return
@@ -44,6 +49,7 @@ def typed_message(payload):
              'name': current_user.name,
         }
         emit('user_message', {'user': user, 'message': payload['msg']}, room=room.name)
+
 
 @socketio.on('text')
 @login_required


### PR DESCRIPTION
The idea is that the server reacts on `typed_message` event and emit `user_message` event to the designated room and user to show what the other user is typing. For the front end part, I think this can be managed by creating logic in `app/static/js/text.js` to handle `user_message` event. To get the current text that the user is typing, a keyup event listener can be added, which is executed when the user is typing in the chat box, where the element can be retrieved from `app/templates/chat.html` via its ID and emit `typed_message` event to the server.