### PR TITLE
Upgrade Docker to Python 3.9 and fix dependencies

### DIFF
--- a/docker/slurk/Dockerfile
+++ b/docker/slurk/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.2
+FROM python:3.9
 
 RUN mkdir -p /usr/src/slurk
 WORKDIR /usr/src/slurk

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,35 @@
-# Server
-Flask == 1.0.2
-Flask-Login == 0.4.1
-Flask-SocketIO == 3.3.2
-Flask-SQLAlchemy == 2.3.2
-Flask-WTF == 0.14.2
-Flask-HTTPAuth == 3.2.4
-WTForms == 2.2.1
-bson == 0.5.8
-
-# Tools and utilities
-Werkzeug == 0.15.3
-SQLAlchemy-utils == 0.33.11
-psycopg2-binary == 2.8.1
-
-# Deployment
-gevent == 1.4.0
-gevent-websocket == 0.10.1
-gunicorn == 19.9.0
-
-# Bots
-SocketIO-client == 0.7.2
-
-# other libs
-tornado == 6.0.3
+bidict==0.21.2
+bson==0.5.10
+certifi==2020.12.5
+chardet==4.0.0
+click==7.1.2
+Flask==1.1.2
+Flask-HTTPAuth==4.2.0
+Flask-Login==0.5.0
+Flask-SocketIO==5.0.1
+Flask-SQLAlchemy==2.5.1
+Flask-WTF==0.14.3
+gevent==21.1.2
+gevent-websocket==0.10.1
+greenlet==1.0.0
+gunicorn==20.1.0
+idna==2.10
+itsdangerous==1.1.0
+Jinja2==2.11.3
+MarkupSafe==1.1.1
+psycopg2-binary==2.8.6
+python-dateutil==2.8.1
+python-engineio==4.1.0
+python-socketio==5.2.1
+requests==2.25.1
+six==1.15.0
+socketIO-client==0.7.2
+SQLAlchemy==1.3.24
+SQLAlchemy-Utils==0.33.11
+tornado==6.1
+urllib3==1.26.4
+websocket-client==0.58.0
+Werkzeug==1.0.1
+WTForms==2.3.3
+zope.event==4.5.0
+zope.interface==5.4.0


### PR DESCRIPTION
SQLAlchemy changed a lot of its interfaces in 1.4 so it has to be pinned to 1.3. Also, GUnicorn required an update as it spawned infinite workers with the current version.