### PR TITLE
Make video location configurable

### DIFF
--- a/app/models/layout.py
+++ b/app/models/layout.py
@@ -197,7 +197,7 @@ class Layout(Common):
     show_users = Column(Boolean, nullable=False)
     show_latency = Column(Boolean, nullable=False)
     read_only = Column(Boolean, nullable=False)
-    openvidu_connection_settings = Column(PickleType, nullable=False)
+    openvidu_settings = Column(PickleType, nullable=False)
 
     @classmethod
     def from_json(cls, json_data):
@@ -264,5 +264,5 @@ class Layout(Common):
             show_users=data.get('show_users', True),
             show_latency=data.get('show_latency', True),
             read_only=data.get('read_only', True),
-            openvidu_connection_settings = data.get('openvidu_connection_settings')
+            openvidu_settings = data.get('openvidu_settings')
         )

--- a/app/models/token.py
+++ b/app/models/token.py
@@ -19,7 +19,7 @@ class Token(Common):
     logins_left = Column(Integer, nullable=False)
     task_id = Column(Integer, ForeignKey('Task.id'))
     room_id = Column(Integer, ForeignKey('Room.id'))
-    openvidu_connection_settings = Column(PickleType, nullable=False)
+    openvidu_settings = Column(PickleType, nullable=False)
 
     task = relationship('Task')
     room = relationship('Room')
@@ -41,7 +41,7 @@ class Token(Common):
                         send_command=False,
                     ),
                     logins_left=-1,
-                    openvidu_connection_settings={}
+                    openvidu_settings={}
                 )
                 session.add(token)
                 session.commit()

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,3 +1,4 @@
+from app.models import token
 from datetime import datetime
 
 from sqlalchemy import Column, String, ForeignKey
@@ -68,10 +69,10 @@ class User(Common):
             # Create an OpenVidu connection if apropiate
             if hasattr(current_app, 'openvidu') and room.openvidu_session_id and self.token.permissions.openvidu_role:
                 def ov_property(name):
-                    setting = self.token.openvidu_settings.get(name)
-                    if setting is None or hasattr(setting, '__len__') and len(setting) == 0:
-                        setting = room.layout.openvidu_settings[name]
-                    return setting
+                    if name in self.token.openvidu_settings:
+                        return self.token.openvidu_settings[name]
+                    else:
+                        return room.layout.openvidu_settings[name]
 
                 # OpenVidu destroys a session when everyone left.
                 # This ensures, that the session is persistant by recreating the session
@@ -94,6 +95,8 @@ class User(Common):
                             start_with_video=ov_property('start_with_video'),
                             video_resolution=ov_property('video_resolution'),
                             video_framerate=ov_property('video_framerate'),
+                            video_publisher_location=ov_property('video_publisher_location'),
+                            video_subscribers_location=ov_property('video_subscribers_location'),
                         ), room=self.session_id)
                     elif response.status_code == 404:
                         json = room.session.parameters

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -68,9 +68,9 @@ class User(Common):
             # Create an OpenVidu connection if apropiate
             if hasattr(current_app, 'openvidu') and room.openvidu_session_id and self.token.permissions.openvidu_role:
                 def ov_property(name):
-                    setting = self.token.openvidu_connection_settings.get(name)
+                    setting = self.token.openvidu_settings.get(name)
                     if setting is None or hasattr(setting, '__len__') and len(setting) == 0:
-                        setting = room.layout.openvidu_connection_settings[name]
+                        setting = room.layout.openvidu_settings[name]
                     return setting
 
                 # OpenVidu destroys a session when everyone left.

--- a/app/views/api/layouts.py
+++ b/app/views/api/layouts.py
@@ -21,7 +21,7 @@ script_dict = ma.Schema.from_dict({
 }, name='Scripts')
 
 
-class OpenViduConnectionSettingsFallbackSchema(BaseSchema):
+class OpenViduSettingsFallbackSchema(BaseSchema):
     start_with_audio = ma.fields.Boolean(
         missing=True,
         description='Start audio on joining the room')
@@ -101,9 +101,9 @@ class LayoutSchema(CommonSchema):
         missing=False,
         description='Make the room read-only',
         filter_description='Filter for the layout being read-only')
-    openvidu_connection_settings = ma.fields.Nested(
-        OpenViduConnectionSettingsFallbackSchema,
-        missing=OpenViduConnectionSettingsFallbackSchema().load({}),
+    openvidu_settings = ma.fields.Nested(
+        OpenViduSettingsFallbackSchema,
+        missing=OpenViduSettingsFallbackSchema().load({}),
         description='Settings for connections used for this layout'
     )
 

--- a/app/views/api/layouts.py
+++ b/app/views/api/layouts.py
@@ -46,6 +46,14 @@ class OpenViduSettingsFallbackSchema(BaseSchema):
     video_max_send_bandwidth = ma.fields.Integer(
         missing=1000,
         description='Maximum video bandwidth sent from OpenVidu Server to clients, in kbps. 0 means unconstrained')
+    video_publisher_location = ma.fields.String(
+        missing='header',
+        allow_none=True,
+        description='Corresponding id in html where publisher video is shown')
+    video_subscribers_location = ma.fields.String(
+        missing='sidebar',
+        allow_none=True,
+        description='Corresponding id in html where subscribed videos are shown')
     allowed_filters = ma.fields.List(
         ma.fields.String,
         missing=[],

--- a/app/views/api/tokens.py
+++ b/app/views/api/tokens.py
@@ -19,7 +19,7 @@ class TokenId(ma.fields.UUID):
         return id
 
 
-class OpenViduConnectionSettingsSchema(BaseSchema):
+class OpenViduSettingsSchema(BaseSchema):
     start_with_audio = ma.fields.Boolean(
         missing=None,
         description='Start audio on joining the room')
@@ -76,9 +76,9 @@ class TokenSchema(CommonSchema):
         missing=None,
         description='Room assigned to this token',
         filter_description='Filter for rooms')
-    openvidu_connection_settings = ma.fields.Nested(
-        OpenViduConnectionSettingsSchema,
-        missing=OpenViduConnectionSettingsSchema().load({}),
+    openvidu_settings = ma.fields.Nested(
+        OpenViduSettingsSchema,
+        missing=OpenViduSettingsSchema().load({}),
         description='Settings for connections used for this token. If a setting is missing, the room default is used'
     )
 

--- a/app/views/api/tokens.py
+++ b/app/views/api/tokens.py
@@ -21,32 +21,29 @@ class TokenId(ma.fields.UUID):
 
 class OpenViduSettingsSchema(BaseSchema):
     start_with_audio = ma.fields.Boolean(
-        missing=None,
         description='Start audio on joining the room')
     start_with_video = ma.fields.Boolean(
-        missing=None,
         description='Start video on joining the room')
     video_resolution = ma.fields.String(
-        missing=None,
         description='Video resolution')
     video_framerate = ma.fields.Integer(
-        missing=None,
         description='Framerate for video')
     video_min_recv_bandwidth = ma.fields.Integer(
-        missing=None,
         description='Minimum video bandwidth sent from clients to OpenVidu Server, in kbps. 0 means unconstrained')
     video_max_recv_bandwidth = ma.fields.Integer(
-        missing=None,
         description='Maximum video bandwidth sent from clients to OpenVidu Server, in kbps. 0 means unconstrained')
     video_min_send_bandwidth = ma.fields.Integer(
-        missing=None,
         description='Minimum video bandwidth sent from OpenVidu Server to clients, in kbps. 0 means unconstrained')
     video_max_send_bandwidth = ma.fields.Integer(
-        missing=None,
         description='Maximum video bandwidth sent from OpenVidu Server to clients, in kbps. 0 means unconstrained')
+    video_publisher_location = ma.fields.String(
+        allow_none=True,
+        description='Corresponding id in html where publisher video is shown')
+    video_subscribers_location = ma.fields.String(
+        allow_none=True,
+        description='Corresponding id in html where subscribed videos are shown')
     allowed_filters = ma.fields.List(
         ma.fields.String,
-        missing=[],
         description='Names of the filters the Connection will be able to apply to its published streams')
 
 

--- a/app/views/static/css/chat.css
+++ b/app/views/static/css/chat.css
@@ -104,12 +104,6 @@ header video {
     overflow: hidden;
     display: flex;
 }
-#ov-subscribers {
-    align-content: left;
-}
-#ov-publisher {
-    text-align: right;
-}
 
 .other .msg {
     border-top-left-radius: 0;

--- a/app/views/static/js/connection.js
+++ b/app/views/static/js/connection.js
@@ -131,7 +131,10 @@ $(document).ready(() => {
         session = OV.initSession()
 
         session.on("streamCreated", event => {
-            let subscriber = session.subscribe(event.stream, document.querySelector('#sidebar #video'));
+            let subscriber = session.subscribe(event.stream, data.video_subscribers_location,
+                {
+                    insertMode: 'APPEND',
+                });
         })
 
         session.on('exception', exception => {
@@ -139,7 +142,7 @@ $(document).ready(() => {
         });
 
         session.connect(data.connection.token).then(() => {
-            let publisher = OV.initPublisher(document.querySelector('header nav'),
+            let publisher = OV.initPublisher(document.querySelector(data.video_publisher_location),
                 {
                     audioSource: undefined,                 // The source of audio. If undefined default microphone
                     videoSource: undefined,                 // The source of video. If undefined default webcam
@@ -147,6 +150,7 @@ $(document).ready(() => {
                     publishVideo: data.start_with_video,  	// Whether you want to start publishing with your video enabled or not
                     resolution: data.video_resolution,      // The resolution of your video
                     frameRate: data.video_framerate,		// The frame rate of your video
+                    insertMode: 'APPEND',
                 })
             // publisher.addVideoElement(document.querySelector('header video'))
 

--- a/app/views/templates/chat.html
+++ b/app/views/templates/chat.html
@@ -26,7 +26,7 @@
 </head>
 
 <body>
-    <header>
+    <header id="header">
         <nav>
             <h1 id="title" class="fade"></h1>
             <h2 id="subtitle" class="fade"></h2>
@@ -35,7 +35,6 @@
         </nav>
     </header>
     <div id="sidebar" class="fade">
-        <div id="video"></div>
         <div id="custom"></div>
     </div>
     <div id="content">

--- a/scripts/create_video_test_setup.sh
+++ b/scripts/create_video_test_setup.sh
@@ -167,7 +167,7 @@ function create_layout {
             "submit-message": ["send-message"],
             "print-history": ["plain-history"]
         },
-        "openvidu_connection_settings": {
+        "openvidu_settings": {
             "video_resolution": "320x240",
             "video_framerate": 60,
             "video_max_recv_bandwidth": 0,
@@ -256,7 +256,7 @@ function create_token {
     local json="{
         \"room_id\": $ROOM,
         \"permissions_id\": $PERMISSIONS,
-        \"openvidu_connection_settings\": {
+        \"openvidu_settings\": {
             \"start_with_audio\": false
         }
     }"


### PR DESCRIPTION
Plan: Add `video_publisher_location` and `video_subscriber_location` where an HTML Id is passed. This defaults to the Id in the header and the sidebar, but can be set to arbitrary values or even to `null` to hide the video.