### PR TITLE
Replace invalid access to attribute `user` of `Token`

### DIFF
--- a/app/models/token.py
+++ b/app/models/token.py
@@ -21,7 +21,7 @@ class Token(Common):
 
     task = relationship('Task')
     room = relationship('Room')
-    users = relationship('User', backref='token')
+    users = relationship('User', backref='token', lazy="dynamic")
 
     @staticmethod
     def get_admin_token(db, id=None):

--- a/app/views/login/__init__.py
+++ b/app/views/login/__init__.py
@@ -37,15 +37,17 @@ def load_user_from_request(request):
     if not token:
         return None
 
-    if not token.user:
-        name = request.headers.get('name')
-        if not name:
-            name = request.args.get('name')
-        if not name:
-            name = "<unnamed>"
-        token.user = User(name=name, rooms=[token.room])
+    name = request.headers.get('name') or request.args.get('name')
+    if not name:
+        name = '<unnamed>'
+
+    user = token.users.filter_by(name=name, session_id=None).one_or_none()
+
+    if not user:
+        user = User(name=name, token=token, rooms=[token.room])
+        db.add(user)
         db.commit()
-    return token.user
+    return user
 
 
 @login.route('/', methods=['GET', 'POST'])


### PR DESCRIPTION
Only a preliminary working solution. The following aspects have to be kept in mind and improved upon:
+ One should not filter the list of all users assigned to a token by `name` as this attribute can be actively modified
+ The filtering for session_id can cause a data race if several bots try to connect simultaneously
+ Depending on the final approach one may have to add logic managing `logins_left`
