### PR TITLE
Modify common patch method

### DIFF
--- a/app/views/api/__init__.py
+++ b/app/views/api/__init__.py
@@ -156,7 +156,7 @@ class CommonSchema(BaseSchema):
         return old
 
     def patch(self, old, new):
-        for field in self.load_fields.keys():
+        for field in self.fields.keys():
             if field in new:
                 setattr(old, field, new[field])
         current_app.session.commit()

--- a/app/views/api/rooms.py
+++ b/app/views/api/rooms.py
@@ -71,7 +71,7 @@ class RoomById(MethodView):
     @blp.login_required
     def patch(self, new_room, *, room):
         """Update a room identified by ID"""
-        return RoomSchema.Update().patch(room, new_room)
+        return RoomSchema().patch(room, new_room)
 
     @blp.etag
     @blp.query('room', RoomSchema)

--- a/app/views/api/tasks.py
+++ b/app/views/api/tasks.py
@@ -71,7 +71,7 @@ class TaskById(MethodView):
     @blp.login_required
     def patch(self, new_task, *, task):
         """Update a task identified by ID"""
-        return TaskSchema.Update().patch(task, new_task)
+        return TaskSchema().patch(task, new_task)
 
     @blp.etag
     @blp.query('task', TaskSchema)

--- a/app/views/api/tokens.py
+++ b/app/views/api/tokens.py
@@ -89,7 +89,7 @@ class TokensById(MethodView):
     @blp.login_required
     def patch(self, new_token, *, token):
         """Update a token identified by ID"""
-        return TokenSchema.Update().patch(token, new_token)
+        return TokenSchema().patch(token, new_token)
 
     @blp.etag
     @blp.query('token', TokenSchema)

--- a/app/views/api/users.py
+++ b/app/views/api/users.py
@@ -73,7 +73,7 @@ class UserById(MethodView):
     @blp.login_required
     def patch(self, new_user, *, user):
         """Update a user identified by ID"""
-        return UserSchema.Update().patch(user, new_user)
+        return UserSchema().patch(user, new_user)
 
     @blp.etag
     @blp.query('user', UserSchema)


### PR DESCRIPTION
`dump_only` fields couldn't be set before.
The name alludes that one actually shouldn't be able to set them.
But we have this one place where `html_obj` as loadable field is saved to the
`html` dump only field. And this `html` field one should then actually be able to modify.
As there exists one field (User.token_id) that is `load_only` but
one might wish to modify, iterating over `dump_fields` is not a valid option.