### PR TITLE
Reintroduce import statement and improve request_loader

### DIFF
--- a/slurk/views/login/__init__.py
+++ b/slurk/views/login/__init__.py
@@ -1,3 +1,5 @@
+import re
+
 from flask import (
     render_template,
     redirect,
@@ -13,6 +15,7 @@ from slurk.extensions.login import login_manager
 from slurk.models import User, Token
 
 from .forms import LoginForm
+from .events import *  # NOQA
 
 
 login = Blueprint("login", __name__, url_prefix="/login")
@@ -32,10 +35,11 @@ def load_user(id):
 def load_user_from_request(request):
     token_id = request.headers.get("Authorization") or request.args.get("token")
     user_id = request.args.get("user") or request.headers.get("user")
+
     if token_id is None or user_id is None:
         return None
 
-    token_id = token_id.upper().lstrip("BEARER").strip()
+    token_id = re.sub("bearer\s+", '', token_id, flags=re.IGNORECASE)
 
     current_app.logger.debug(f"loading user `{user_id}` from token `{token_id}`")
 

--- a/slurk/views/login/__init__.py
+++ b/slurk/views/login/__init__.py
@@ -15,7 +15,7 @@ from slurk.extensions.login import login_manager
 from slurk.models import User, Token
 
 from .forms import LoginForm
-from .events import *  # NOQA
+import slurk.views.login.events  # NOQA
 
 
 login = Blueprint("login", __name__, url_prefix="/login")
@@ -39,7 +39,7 @@ def load_user_from_request(request):
     if token_id is None or user_id is None:
         return None
 
-    token_id = re.sub("bearer\s+", '', token_id, flags=re.IGNORECASE)
+    token_id = re.sub(r"bearer\s+", "", token_id, flags=re.IGNORECASE)
 
     current_app.logger.debug(f"loading user `{user_id}` from token `{token_id}`")
 


### PR DESCRIPTION
The import statement `from .events import *` is necessary. If removed the `connect` event
is not caught by the appropriate socketio handler. Stripping BEARER from a token can cause
problems if the token starts with one of the letters in BEARER and it is passed alone. Additionally
the database seems to be case-sensitive so capitalizing the token_id did also cause problems.