### PR TITLE
Add a value type for `"css"` field for the layout schema

### DIFF
--- a/slurk/views/api/layouts.py
+++ b/slurk/views/api/layouts.py
@@ -109,6 +109,9 @@ class LayoutSchema(CommonSchema):
         description="HTML used in the layout",
     )
     css_obj = ma.fields.Dict(
+        values=ma.fields.Dict(
+            description="Dictionary of CSS declarations mapping a CSS value to a CSS property",
+        ),
         data_key="css",
         load_only=True,
         missing={},


### PR DESCRIPTION
Passing an invalid object as CSS for creating/altering a layout, results in an internal server error. This adds a value type to catch this error. 