### PR TITLE
Add option to disable ETag

### DIFF
--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -48,6 +48,7 @@ else
         --name=$SLURK_DOCKER \
         -p $PORT:80 \
         -e SLURK_SECRET_KEY=$SLURK_SECRET_KEY \
+        -e SLURK_DISABLE_ETAG=${SLURK_DISABLE_ETAG:-False} \
         -e FLASK_ENV=$FLASK_ENV \
         $param \
         slurk/server:${SLURK_DOCKER_TAG:-latest}

--- a/slurk/config.py
+++ b/slurk/config.py
@@ -21,6 +21,8 @@ SECRET_KEY = os.environ.get(
 )
 DATABASE = os.environ.get("SLURK_DATABASE_URI", "sqlite:///:memory:")
 
+ETAG_DISABLED = environ_as_boolean("SLURK_DISABLE_ETAG", False)
+
 if "SLURK_OPENVIDU_URL" in os.environ:
     OPENVIDU_URL = os.environ["SLURK_OPENVIDU_URL"]
     OPENVIDU_SECRET = os.environ.get("SLURK_OPENVIDU_SECRET")


### PR DESCRIPTION
When setting `SLURK_DISABLE_ETAG`, it's not required anymore to pass an ETag when altering or deleting an entry.

r? @wencke-lm