### PR TITLE
Add event handler for `room_created`

### DIFF
--- a/slurk/views/chat/events.py
+++ b/slurk/views/chat/events.py
@@ -29,7 +29,7 @@ def room_created(payload):
     socketio.emit(
         "new_task_room",
         {"room": payload["room"], "task": payload["task"], "users": users},
-        broadcast=True
+        broadcast=True,
     )
     return True
 


### PR DESCRIPTION
Reintroduces Event `room_created` that can be sent from a bot to slurk.
As a payload one *has* to pass the identifier of the room that was created (room.id).
One may additionally pass the identifier of a task this room was created for.

The event handler may emit up to two events.
new_room: {"room": <room_id>"} sent to all rooms and connected users
new_task_room: {"room": <room_id>, "task": <task_id>, "users": <list_of_dict {"id": <user_id>, "name": <user_name>}>} sent to all rooms and connected users