### PR TITLE
Make room logs only accessible by users logged in

### DIFF
--- a/slurk/extensions/api.py
+++ b/slurk/extensions/api.py
@@ -85,8 +85,9 @@ class Blueprint(flask_smorest.Blueprint):
 
         if not current_app.config["DEBUG"]:
             wrapper = auth.login_required(func)
-        Blueprint.append_auth_headers(wrapper, func)
-        return wrapper
+            Blueprint.append_auth_headers(wrapper, func)
+            func = wrapper
+        return func
 
     @staticmethod
     def login_possible(func):

--- a/slurk/extensions/api.py
+++ b/slurk/extensions/api.py
@@ -83,7 +83,8 @@ class Blueprint(flask_smorest.Blueprint):
         from slurk.views.api.auth import auth
         from flask.globals import current_app
 
-        wrapper = auth.login_required(func)
+        if not current_app.config["DEBUG"]:
+            wrapper = auth.login_required(func)
         Blueprint.append_auth_headers(wrapper, func)
         return wrapper
 

--- a/slurk/views/api/auth.py
+++ b/slurk/views/api/auth.py
@@ -18,18 +18,6 @@ class HTTPTokenAuth(_FlaskHTTPTokenAuth):
         def wrapper(*args, **kwargs):
             return auth_required_func(*args, **kwargs)
 
-        # Update the api docs on the wrapped function and return it to be
-        # further decorated by other decorators
-        parameters = {
-            "name": "Authorization",
-            "in": "header",
-            "description": "Authorization: Bearer <access_token>",
-            "required": "true",
-        }
-
-        wrapper._apidoc = getattr(func, "_apidoc", {})
-        wrapper._apidoc.setdefault("parameters", []).append(parameters)
-
         return wrapper
 
 

--- a/slurk/views/api/rooms.py
+++ b/slurk/views/api/rooms.py
@@ -147,7 +147,6 @@ class LogsByUserByRoomById(MethodView):
         if not authenticated and current_user != user:
             abort(HTTPStatus.UNAUTHORIZED)
 
-        # request.headers
         return (
             current_app.session.query(Log)
             .filter_by(room_id=room.id)

--- a/slurk/views/api/rooms.py
+++ b/slurk/views/api/rooms.py
@@ -1,5 +1,6 @@
 from flask.views import MethodView
 from flask.globals import current_app
+from flask_login import current_user
 from flask_smorest import abort
 from flask_smorest.error_handler import ErrorSchema
 from http import HTTPStatus
@@ -140,8 +141,13 @@ class LogsByUserByRoomById(MethodView):
     @blp.query("room", RoomSchema)
     @blp.query("user", UserSchema)
     @blp.response(200, LogSchema.Response(many=True))
-    def get(self, *, room, user):
+    @blp.login_possible
+    def get(self, *, room, user, authenticated):
         """List logs by room and user"""
+        if not authenticated and current_user != user:
+            abort(HTTPStatus.UNAUTHORIZED)
+
+        # request.headers
         return (
             current_app.session.query(Log)
             .filter_by(room_id=room.id)

--- a/tests/api/test_rooms.py
+++ b/tests/api/test_rooms.py
@@ -761,3 +761,15 @@ class TestGetLogsByUserByRoomByIdValid:
             headers={"If-None-Match": response.headers["ETag"]},
         )
         assert response.status_code == HTTPStatus.NOT_MODIFIED
+
+
+class TestGetLogsByUserByRoomByIdInvalid:
+    @pytest.mark.depends(
+        on=["tests/api/test_rooms.py::TestGetLogsByUserByRoomByIdValid"]
+    )
+    def test_unauthorized_access(self, client, rooms, users, tokens):
+        response = client.get(
+            f'/slurk/api/rooms/{rooms.json["id"]}/users/{users.json["id"]}/logs',
+            headers={"Authorization": f'Bearer {tokens.json["id"]}'},
+        )
+        assert response.status_code == HTTPStatus.UNAUTHORIZED, parse_error(response)


### PR DESCRIPTION
This adds a new decorator: `login_possible`, which adds the parameter `authorized` to the decorated function. This is a boolean value indicating if the request was made with a valid API token.

r? @wencke-lm 