### PR TITLE
Wait for status event until join has finished

### DIFF
--- a/slurk/models/user.py
+++ b/slurk/models/user.py
@@ -5,7 +5,6 @@ from sqlalchemy.orm import relationship
 
 from .common import Common, user_room
 from .log import Log
-from .room import Room
 
 
 class User(Common):

--- a/slurk/models/user.py
+++ b/slurk/models/user.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import relationship
 
 from .common import Common, user_room
 from .log import Log
+from .room import Room
 
 
 class User(Common):
@@ -50,98 +51,103 @@ class User(Common):
         if self.session_id is not None:
             join_room(str(room.id), self.session_id, "/")
 
+            def joined():
+                current_app.session.add(self)
+                current_app.session.add(room)
+
+                socketio.emit(
+                    "status",
+                    dict(
+                        type="join",
+                        user=dict(id=self.id, name=self.name),
+                        room=str(room.id),
+                        timestamp=str(datetime.utcnow()),
+                    ),
+                    room=str(room.id),
+                )
+
+                Log.add("join", self, room)
+
+                # Create an OpenVidu connection if apropiate
+                if (
+                    hasattr(current_app, "openvidu")
+                    and room.openvidu_session_id
+                    and self.token.permissions.openvidu_role
+                ):
+
+                    def ov_property(name):
+                        if name in self.token.openvidu_settings:
+                            return self.token.openvidu_settings[name]
+                        else:
+                            return room.layout.openvidu_settings[name]
+
+                    # OpenVidu destroys a session when everyone left.
+                    # This ensures, that the session is persistant by recreating the session
+                    def post_connection(retry=True):
+                        response = current_app.openvidu.post_connection(
+                            room.openvidu_session_id,
+                            json=dict(
+                                role=self.token.permissions.openvidu_role,
+                                kurentoOptions=dict(
+                                    videoMaxRecvBandwidth=ov_property(
+                                        "video_max_recv_bandwidth"
+                                    ),
+                                    videoMinRecvBandwidth=ov_property(
+                                        "video_min_recv_bandwidth"
+                                    ),
+                                    videoMaxSendBandwidth=ov_property(
+                                        "video_max_send_bandwidth"
+                                    ),
+                                    videoMinSendBandwidth=ov_property(
+                                        "video_min_send_bandwidth"
+                                    ),
+                                    allowedFilters=ov_property("allowed_filters"),
+                                ),
+                            ),
+                        )
+
+                        if response.status_code == 200:
+                            socketio.emit(
+                                "openvidu",
+                                dict(
+                                    connection=WebRtcConnectionSchema.Response().dump(
+                                        response.json()
+                                    ),
+                                    start_with_audio=ov_property("start_with_audio"),
+                                    start_with_video=ov_property("start_with_video"),
+                                    video_resolution=ov_property("video_resolution"),
+                                    video_framerate=ov_property("video_framerate"),
+                                    video_publisher_location=ov_property(
+                                        "video_publisher_location"
+                                    ),
+                                    video_subscribers_location=ov_property(
+                                        "video_subscribers_location"
+                                    ),
+                                ),
+                                room=self.session_id,
+                            )
+                        elif response.status_code == 404:
+                            json = room.session.parameters
+                            json["customSessionId"] = room.session.id
+                            response = current_app.openvidu.post_session(json)
+                            if response.status_code == 200:
+                                post_connection(retry=False)
+                            else:
+                                current_app.logger.error(response.json().get("message"))
+                        else:
+                            current_app.logger.error(response.json().get("message"))
+
+                    post_connection()
+
             socketio.emit(
                 "joined_room",
                 {
-                    "room": room.id,
+                    "room": str(room.id),
                     "user": self.id,
                 },
                 room=self.session_id,
+                callback=joined,
             )
-
-            socketio.emit(
-                "status",
-                dict(
-                    type="join",
-                    user=dict(id=self.id, name=self.name),
-                    room=room.id,
-                    timestamp=str(datetime.utcnow()),
-                ),
-                room=str(room.id),
-            )
-
-            Log.add("join", self, room)
-
-            # Create an OpenVidu connection if apropiate
-            if (
-                hasattr(current_app, "openvidu")
-                and room.openvidu_session_id
-                and self.token.permissions.openvidu_role
-            ):
-
-                def ov_property(name):
-                    if name in self.token.openvidu_settings:
-                        return self.token.openvidu_settings[name]
-                    else:
-                        return room.layout.openvidu_settings[name]
-
-                # OpenVidu destroys a session when everyone left.
-                # This ensures, that the session is persistant by recreating the session
-                def post_connection(retry=True):
-                    response = current_app.openvidu.post_connection(
-                        room.openvidu_session_id,
-                        json=dict(
-                            role=self.token.permissions.openvidu_role,
-                            kurentoOptions=dict(
-                                videoMaxRecvBandwidth=ov_property(
-                                    "video_max_recv_bandwidth"
-                                ),
-                                videoMinRecvBandwidth=ov_property(
-                                    "video_min_recv_bandwidth"
-                                ),
-                                videoMaxSendBandwidth=ov_property(
-                                    "video_max_send_bandwidth"
-                                ),
-                                videoMinSendBandwidth=ov_property(
-                                    "video_min_send_bandwidth"
-                                ),
-                                allowedFilters=ov_property("allowed_filters"),
-                            ),
-                        ),
-                    )
-
-                    if response.status_code == 200:
-                        socketio.emit(
-                            "openvidu",
-                            dict(
-                                connection=WebRtcConnectionSchema.Response().dump(
-                                    response.json()
-                                ),
-                                start_with_audio=ov_property("start_with_audio"),
-                                start_with_video=ov_property("start_with_video"),
-                                video_resolution=ov_property("video_resolution"),
-                                video_framerate=ov_property("video_framerate"),
-                                video_publisher_location=ov_property(
-                                    "video_publisher_location"
-                                ),
-                                video_subscribers_location=ov_property(
-                                    "video_subscribers_location"
-                                ),
-                            ),
-                            room=self.session_id,
-                        )
-                    elif response.status_code == 404:
-                        json = room.session.parameters
-                        json["customSessionId"] = room.session.id
-                        response = current_app.openvidu.post_session(json)
-                        if response.status_code == 200:
-                            post_connection(retry=False)
-                        else:
-                            current_app.logger.error(response.json().get("message"))
-                    else:
-                        current_app.logger.error(response.json().get("message"))
-
-                post_connection()
 
     def leave_room(self, room, event_only=False):
         from flask.globals import current_app

--- a/slurk/models/user.py
+++ b/slurk/models/user.py
@@ -50,103 +50,103 @@ class User(Common):
         if self.session_id is not None:
             join_room(str(room.id), self.session_id, "/")
 
-            def joined():
-                current_app.session.add(self)
-                current_app.session.add(room)
+            user = dict(id=self.id, name=self.name)
+            room_id = room.id
 
+            def joined():
                 socketio.emit(
                     "status",
                     dict(
                         type="join",
-                        user=dict(id=self.id, name=self.name),
-                        room=str(room.id),
+                        user=dict(id=user["id"], name=user["name"]),
+                        room=room_id,
                         timestamp=str(datetime.utcnow()),
                     ),
-                    room=str(room.id),
+                    room=str(room_id),
                 )
-
-                Log.add("join", self, room)
-
-                # Create an OpenVidu connection if apropiate
-                if (
-                    hasattr(current_app, "openvidu")
-                    and room.openvidu_session_id
-                    and self.token.permissions.openvidu_role
-                ):
-
-                    def ov_property(name):
-                        if name in self.token.openvidu_settings:
-                            return self.token.openvidu_settings[name]
-                        else:
-                            return room.layout.openvidu_settings[name]
-
-                    # OpenVidu destroys a session when everyone left.
-                    # This ensures, that the session is persistant by recreating the session
-                    def post_connection(retry=True):
-                        response = current_app.openvidu.post_connection(
-                            room.openvidu_session_id,
-                            json=dict(
-                                role=self.token.permissions.openvidu_role,
-                                kurentoOptions=dict(
-                                    videoMaxRecvBandwidth=ov_property(
-                                        "video_max_recv_bandwidth"
-                                    ),
-                                    videoMinRecvBandwidth=ov_property(
-                                        "video_min_recv_bandwidth"
-                                    ),
-                                    videoMaxSendBandwidth=ov_property(
-                                        "video_max_send_bandwidth"
-                                    ),
-                                    videoMinSendBandwidth=ov_property(
-                                        "video_min_send_bandwidth"
-                                    ),
-                                    allowedFilters=ov_property("allowed_filters"),
-                                ),
-                            ),
-                        )
-
-                        if response.status_code == 200:
-                            socketio.emit(
-                                "openvidu",
-                                dict(
-                                    connection=WebRtcConnectionSchema.Response().dump(
-                                        response.json()
-                                    ),
-                                    start_with_audio=ov_property("start_with_audio"),
-                                    start_with_video=ov_property("start_with_video"),
-                                    video_resolution=ov_property("video_resolution"),
-                                    video_framerate=ov_property("video_framerate"),
-                                    video_publisher_location=ov_property(
-                                        "video_publisher_location"
-                                    ),
-                                    video_subscribers_location=ov_property(
-                                        "video_subscribers_location"
-                                    ),
-                                ),
-                                room=self.session_id,
-                            )
-                        elif response.status_code == 404:
-                            json = room.session.parameters
-                            json["customSessionId"] = room.session.id
-                            response = current_app.openvidu.post_session(json)
-                            if response.status_code == 200:
-                                post_connection(retry=False)
-                            else:
-                                current_app.logger.error(response.json().get("message"))
-                        else:
-                            current_app.logger.error(response.json().get("message"))
-
-                    post_connection()
 
             socketio.emit(
                 "joined_room",
                 {
-                    "room": str(room.id),
+                    "room": room.id,
                     "user": self.id,
                 },
                 room=self.session_id,
                 callback=joined,
             )
+
+            Log.add("join", self, room)
+
+            # Create an OpenVidu connection if apropiate
+            if (
+                hasattr(current_app, "openvidu")
+                and room.openvidu_session_id
+                and self.token.permissions.openvidu_role
+            ):
+
+                def ov_property(name):
+                    if name in self.token.openvidu_settings:
+                        return self.token.openvidu_settings[name]
+                    else:
+                        return room.layout.openvidu_settings[name]
+
+                # OpenVidu destroys a session when everyone left.
+                # This ensures, that the session is persistant by recreating the session
+                def post_connection(retry=True):
+                    response = current_app.openvidu.post_connection(
+                        room.openvidu_session_id,
+                        json=dict(
+                            role=self.token.permissions.openvidu_role,
+                            kurentoOptions=dict(
+                                videoMaxRecvBandwidth=ov_property(
+                                    "video_max_recv_bandwidth"
+                                ),
+                                videoMinRecvBandwidth=ov_property(
+                                    "video_min_recv_bandwidth"
+                                ),
+                                videoMaxSendBandwidth=ov_property(
+                                    "video_max_send_bandwidth"
+                                ),
+                                videoMinSendBandwidth=ov_property(
+                                    "video_min_send_bandwidth"
+                                ),
+                                allowedFilters=ov_property("allowed_filters"),
+                            ),
+                        ),
+                    )
+
+                    if response.status_code == 200:
+                        socketio.emit(
+                            "openvidu",
+                            dict(
+                                connection=WebRtcConnectionSchema.Response().dump(
+                                    response.json()
+                                ),
+                                start_with_audio=ov_property("start_with_audio"),
+                                start_with_video=ov_property("start_with_video"),
+                                video_resolution=ov_property("video_resolution"),
+                                video_framerate=ov_property("video_framerate"),
+                                video_publisher_location=ov_property(
+                                    "video_publisher_location"
+                                ),
+                                video_subscribers_location=ov_property(
+                                    "video_subscribers_location"
+                                ),
+                            ),
+                            room=self.session_id,
+                        )
+                    elif response.status_code == 404:
+                        json = room.session.parameters
+                        json["customSessionId"] = room.session.id
+                        response = current_app.openvidu.post_session(json)
+                        if response.status_code == 200:
+                            post_connection(retry=False)
+                        else:
+                            current_app.logger.error(response.json().get("message"))
+                    else:
+                        current_app.logger.error(response.json().get("message"))
+
+                post_connection()
 
     def leave_room(self, room, event_only=False):
         from flask.globals import current_app

--- a/slurk/models/user.py
+++ b/slurk/models/user.py
@@ -58,7 +58,7 @@ class User(Common):
                     "status",
                     dict(
                         type="join",
-                        user=dict(id=user["id"], name=user["name"]),
+                        user=user,
                         room=room_id,
                         timestamp=str(datetime.utcnow()),
                     ),

--- a/slurk/views/static/js/connection.js
+++ b/slurk/views/static/js/connection.js
@@ -77,7 +77,7 @@ $(document).ready(() => {
         user_map = tmp_user_map
     }
 
-    async function joined_room(data) {
+    async function joined_room(data, ack) {
         self_room = data['room'];
 
         let room_request = $.get({ url: uri + "/rooms/" + self_room, beforeSend: headers });
@@ -119,6 +119,7 @@ $(document).ready(() => {
         }
 
         apply_user_permissions(await permissions_request)
+        ack()
     }
 
     async function left_room(data) {


### PR DESCRIPTION
This adds a callback to the `joined_room` event. For the diff view, [whitespace changes should be hidden](https://github.com/clp-research/slurk/pull/207/files?diff=split&w=1).

r? @wencke-lm 