### PR TITLE
Add adapted plugin to enforce fullscreen

### DIFF
--- a/docs/slurk_bots_events.rst
+++ b/docs/slurk_bots_events.rst
@@ -226,3 +226,43 @@ Commands cause an event on the server side that can be handled by bots:
 - ``private(bool)``: ``True`` if this was a private command meant for a single user. ``False`` otherwise
 - ``broadcast(bool)``: ``True`` if the command was transmitted to all connected users. ``False`` otherwise
 - ``timestamp(str)``: as ISO 8601: ``YYYY-MM-DD hh:mm:ss.ssssss`` in UTC Time
+
+Others
+~~~~~~
+For both events below ``coordinates`` are given in percentage. For example an x-value of 0.4 for an image of width 100px should be interpreted as the mouse being 40px to the right of the left corner of the html element.
+
+Mouse Tracking
+--------------
+If one specifies the plain script ``mouse-tracking`` in a room layout bots will receive an additional ``mouse`` event.
+
+.. code-block:: python
+
+    @self.sio.event
+    def mouse(data):
+        do_something(data)
+
+``data`` in ``mouse`` has this structure:
+
+- ``type(str)``: ``click`` if the user clicked on the html element, ``move`` for every few miliseconds of mouse movement
+- ``coordinates(dict)``: contains the keys ``x`` and ``y``, the position ``{"x": 0, "y": 0}`` would be the top left corner of the html element
+- ``element_id(str)``: the ``id`` of the html element in which movement is tracked
+- ``user(dict)``: dictionary of ``id(int)`` and ``name(str)`` of the user who caused this event
+- ``room(int)``: the ``id`` of the room where the event was triggered
+- ``timestamp(str)``: as ISO 8601: ``YYYY-MM-DD hh:mm:ss.ssssss`` in UTC Time
+
+Bounding Boxes
+--------------
+If one specifies the plain script ``bounding-boxes`` in a room layout and assigns a bot the permission ``receive_bounding_box`` it will receive an additional ``bounding_box`` event.
+
+.. code-block:: python
+
+    @self.sio.event
+    def bounding_box(data):
+        do_something(data)
+
+``data`` in ``bounding_box`` has this structure:
+
+- ``type(str)``: ``add`` if a bounding box was added, ``remove`` if the canvas was resetted and all bounding boxes removed in the process
+- ``coordinates(dict, optional)``: only passed for the ``add`` event, contains the keys ``left``, ``top``, ``bottom`` and ``right`` specifying all four corners of the rectangle
+- ``user(dict)``: dictionary of ``id(int)`` and ``name(str)`` of the user who caused this event
+- ``room(int)``: the ``id`` of the room where the event was triggered

--- a/docs/slurk_layouts.rst
+++ b/docs/slurk_layouts.rst
@@ -145,10 +145,11 @@ Examples:
 
 ``"plain"``
 -----------
-"Injected as a script file into the site
+Injected as a script file into the site
 
 Examples:
   - ``"ask-reload"``: A pop-up asks on page reload if this is the desired action
+  - ``"enforce-fullscreen"``: Page content is grayed out, until a button is clicked that sends user into fullscreen. See ``enforce-fullscreen_layout.json`` in ``examples`` for an example layout
 
 ``"document-ready"``
 --------------------

--- a/docs/slurk_layouts.rst
+++ b/docs/slurk_layouts.rst
@@ -150,6 +150,7 @@ Injected as a script file into the site
 Examples:
   - ``"ask-reload"``: A pop-up asks on page reload if this is the desired action
   - ``"enforce-fullscreen"``: Page content is grayed out, until a button is clicked that sends user into fullscreen. See ``enforce-fullscreen_layout.json`` in ``examples`` for an example layout
+  - ``"bounding-boxes"``: Makes it possible for users to draw rectangles inside a designated drawing area (html element with the id ``drawing-area``). Per default, drawn rectangles are not shared between users inside a room. If you wish for all users in a room to share a common canvas give all users inside the room the permission ``receive_bounding_box``
 
 ``"document-ready"``
 --------------------

--- a/docs/slurk_layouts.rst
+++ b/docs/slurk_layouts.rst
@@ -151,6 +151,7 @@ Examples:
   - ``"ask-reload"``: A pop-up asks on page reload if this is the desired action
   - ``"enforce-fullscreen"``: Page content is grayed out, until a button is clicked that sends user into fullscreen. See ``enforce-fullscreen_layout.json`` in ``examples`` for an example layout
   - ``"bounding-boxes"``: Makes it possible for users to draw rectangles inside a designated drawing area (html element with the id ``drawing-area``). Per default, drawn rectangles are not shared between users inside a room. If you wish for all users in a room to share a common canvas give all users inside the room the permission ``receive_bounding_box``
+  - ``"mouse-tracking"``: Mouse movement and clicks inside the designated html element with the id ``tracking-area`` are registered. They can be handled by bots through the ``mouse`` event.
 
 ``"document-ready"``
 --------------------

--- a/examples/enforce-fullscreen_layout.json
+++ b/examples/enforce-fullscreen_layout.json
@@ -1,0 +1,47 @@
+{
+    "title": "Example Layout - Enforce Fullscreen",
+    "html": [
+        {
+            "layout-type": "div",
+            "id": "fullscreen-overlay",
+            "layout-content": [
+                {
+                    "layout-type": "div",
+                    "id": "fullscreenButton",
+                    "class": "button",
+                    "layout-content": "Enter Fullscreen"
+                }
+           ]
+        }
+    ],
+    "css": {
+        "#fullscreenButton:hover": {
+            "background-color": "rgb(129, 139, 172)!important"
+        },
+        "#fullscreen-overlay":{
+            "background-color": "rgba(0,0,0,0.8)",
+            "position": "fixed",
+            "top": "0px",
+            "left": "0px",
+            "height": "100vh",
+            "width": "100vw",
+            "z-index": 3
+        },
+        "#fullscreenButton": {
+            "width": "300px",
+            "height": "100px",
+            "position": "absolute",
+            "left": "calc(50vw - 150px)",
+            "top": "calc(50vh - 90px)",
+            "font-size": "2em",
+            "border-radius": "100px",
+            "line-height": "100px",
+            "background-color": "white",
+            "text-align": "center",
+            "z-index": 4
+        }
+    },
+    "scripts": {
+        "plain": "enforce-fullscreen"
+    }
+}

--- a/slurk/views/static/css/chat.css
+++ b/slurk/views/static/css/chat.css
@@ -26,7 +26,7 @@ header{
     height: 80px;
     border-bottom: #E5E7E9;
     box-shadow: rgba(0,0,0,0.10) 0 1px 1px 0,rgba(0,0,0,0.30) 0 4px 4px 0;
-    z-index: 1;
+    z-index: 5;
 }
 
 header #title {
@@ -70,7 +70,6 @@ header video {
     min-width: 300px;
     max-width: calc(100% - 200px);
     height: 100%;
-    z-index: 0;
 }
 
 #sidebar:after {
@@ -96,6 +95,7 @@ header video {
     max-width: calc(100% - 300px);
     height: calc(100% - 80px - 60px);
     overflow-y: auto;
+    z-index: 0;
 }
 
 #chat-area {
@@ -222,6 +222,7 @@ time:before{
     left: 0;
     right: 0;
     font-size: 1.2em;
+    z-index: 2;
 
     padding: 0 55px;
     width: 100%;

--- a/slurk/views/static/plugins/enforce-fullscreen.js
+++ b/slurk/views/static/plugins/enforce-fullscreen.js
@@ -1,0 +1,69 @@
+//Note: initiating fullscreen with F11 does not remove the overlay
+document.addEventListener("fullscreenchange", fullScreenChange);
+document.addEventListener("mozfullscreenchange", fullScreenChange); // firefox
+document.addEventListener("webkitfullscreenchange", fullScreenChange); // safari, chrome, opera
+document.addEventListener("msfullscreenchange", fullScreenChange); // IE
+
+// enter fullscreen mode
+function enterFullscreen(element) {
+    if (element.requestFullscreen) {
+        element.requestFullscreen();
+    } else if (element.webkitRequestFullscreen) {
+	// safari, chrome, opera
+        element.webkitRequestFullscreen();
+    } else if (element.mozRequestFullScreen) {
+	// firefox
+        element.mozRequestFullScreen();
+    } else if (element.msRequestFullscreen) {
+	// IE
+        element.msRequestFullscreen();
+    }
+}
+
+// disable fullscreen mode
+function closeFullscreen() {
+    if (statusFullScreen()) {
+        if (document.exitFullscreen) {
+            document.exitFullscreen();
+        } else if (document.webkitExitFullscreen) {
+	    // safari, chrome, opera
+            document.webkitExitFullscreen();
+        } else if (document.mozCancelFullScreen) {
+	    // firefox
+            document.mozCancelFullScreen();
+        } else if (document.msExitFullscreen) {
+	    // IE
+            document.msExitFullscreen();
+        }
+    }
+}
+
+// return true if browser is in fullscreen
+function statusFullScreen() {
+    if (
+        document.fullscreenElement
+	|| document.mozFullScreenElement
+	|| document.webkitFullscreenElement
+	|| document.msFullscreenElement
+    ) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+// hide overlay when in fullscreen, show it otherwise
+function fullScreenChange() {
+    if (statusFullScreen()) {
+        $("#fullscreen-overlay").fadeOut();
+    } else {
+        $("#fullscreen-overlay").fadeIn();
+	$("#fullscreenButton").fadeIn();
+    }
+}
+
+
+fullScreenChange();
+$("#fullscreenButton").click(function(e) {
+    enterFullscreen(document.documentElement);
+});


### PR DESCRIPTION
First part of the adapted scripts from the click-bot. Might be nice to try it out on Mac, in my understanding fullscreen there is a little special. I have added an example layout to the appropriate folder.
r? @janagoetze 