### PR TITLE
Add mouse-tracking plugin

### DIFF
--- a/slurk/views/chat/events.py
+++ b/slurk/views/chat/events.py
@@ -79,6 +79,34 @@ def typed_message(payload):
         )
 
 
+@socketio.event
+def mouse(payload):
+    current_user_id = current_user.get_id()
+    if not current_user_id:
+        return False, "invalid session id"
+
+    user = dict(id=current_user_id, name=current_user.name)
+
+    db = current_app.session
+    room = db.query(Room).get(payload["room"]) if "room" in payload else None
+
+    if room is None:
+        return False, "Room not found"
+
+    socketio.emit(
+        "mouse",
+        dict(
+            type=payload.get("type"),
+            coordinates=payload.get("coordinates"),
+            element_id=payload.get("element_id"),
+            user=user,
+            room=room.id,
+            timestamp=str(datetime.utcnow()),
+        ),
+        room=str(room.id),
+    )
+
+
 def emit_message(event, payload, data):
     if "room" not in payload:
         return False, 'missing argument: "room"'

--- a/slurk/views/chat/events.py
+++ b/slurk/views/chat/events.py
@@ -93,18 +93,23 @@ def mouse(payload):
     if room is None:
         return False, "Room not found"
 
+    data = dict(
+        type=payload.get("type"),
+        coordinates=payload.get("coordinates"),
+        element_id=payload.get("element_id"),
+    )
+
     socketio.emit(
         "mouse",
         dict(
-            type=payload.get("type"),
-            coordinates=payload.get("coordinates"),
-            element_id=payload.get("element_id"),
             user=user,
             room=room.id,
             timestamp=str(datetime.utcnow()),
+            **data,
         ),
         room=str(room.id),
     )
+    Log.add(event="mouse", user=current_user, room=room, data=data)
 
 
 def emit_message(event, payload, data):

--- a/slurk/views/static/plugins/mouse-tracking.js
+++ b/slurk/views/static/plugins/mouse-tracking.js
@@ -16,7 +16,6 @@ function getPosition (evt, area) {
 
 function emitPosition(area) {
     if (mousePointer.isMoving) {
-        console.log(mousePointer.pos)
         socket.emit("mouse", {
            type: "move",
            coordinates: mousePointer.pos,
@@ -37,7 +36,6 @@ function trackMovement(area, interval) {
 
 function trackClicks(area) {
     $("#" + area).click(function(e) {
-	console.log('You clicked.');
         getPosition(e, area);
         socket.emit("mouse", {
             type: "click",

--- a/slurk/views/static/plugins/mouse-tracking.js
+++ b/slurk/views/static/plugins/mouse-tracking.js
@@ -1,0 +1,53 @@
+// the tracking area should have a fixed size in px
+// padding and border-width but not margin will count as part of the area
+let trackingArea = "tracking-area"
+
+let mousePointer = {
+    isMoving: false,
+    pos: {x: undefined, y: undefined}
+};
+
+function getPosition (evt, area) {
+    let elem = document.getElementById(area);
+    let position = elem.getBoundingClientRect();
+    mousePointer.pos.x = (evt.clientX - position.left) / position.width;
+    mousePointer.pos.y = (evt.clientY - position.top) / position.height;
+}
+
+function emitPosition(area) {
+    if (mousePointer.isMoving) {
+        console.log(mousePointer.pos)
+        socket.emit("mouse", {
+           type: "move",
+           coordinates: mousePointer.pos,
+           element_id: area,
+           room: self_room
+	});
+        mousePointer.isMoving = false;
+    }
+}
+
+function trackMovement(area, interval) {
+    $("#" + area).mousemove(function(e) {
+        getPosition(e, area);
+        mousePointer.isMoving = true;
+    });
+    setInterval(emitPosition, interval, area);
+}
+
+function trackClicks(area) {
+    $("#" + area).click(function(e) {
+	console.log('You clicked.');
+        getPosition(e, area);
+        socket.emit("mouse", {
+            type: "click",
+            coordinates: mousePointer.pos,
+            element_id: area,
+            room: self_room
+        });
+    });
+}
+
+// get position within trackingArea every 100 ms
+trackMovement(trackingArea, 100);
+trackClicks(trackingArea);


### PR DESCRIPTION
As one may notice, so far no mouse events are logged.
Things to consider if we log mouse events on the server side as we normally do for other events:
- mouse movement on the designated html element causes an event to be triggered every 100ms, that would create hundreds of log entries
- those events are only triggered and therefore logged if the user specifies the mouse-tracking script, so the user is probably interested in logging these events
- all relevant information for each mouse event is emitted, a bot could catch that and manually save mouse events somewhere separately 

I think the slurk running on the university server has over a thousand logs by now... What is your experience working with those in terms of GETing them from the server and filtering them? Does it matter whether there are several thousand more logs?
@luise-strietzel 