### PR TITLE
Fix bug occuring upon server restart

### DIFF
--- a/slurk/models/token.py
+++ b/slurk/models/token.py
@@ -42,7 +42,7 @@ class Token(Common):
                 session.query(Token)
                 .filter_by(registrations_left=-1)
                 .filter(Token.permissions.has(Permissions.api))
-                .one_or_none()
+                .first()
             )
             if not token:
                 token = Token(


### PR DESCRIPTION
Either we do it like that or we enforce that only one token can have the characteristics of an admin token. At the moment those characteristics are that the token can be used infinitely and it has api rights.