### PR TITLE
Elaborate on deployment

### DIFF
--- a/docs/slurk_deployment.rst
+++ b/docs/slurk_deployment.rst
@@ -110,3 +110,41 @@ First, we start the postgres-container, named ``db``. We define the password to 
 to the database and mount the database content to ``/path/to/postgres/data``.
 When postgres has started, we pass the postgres URI to slurk, alongside a secret key.
 As we also want OpenVidu support, the two required OpenVidu-variables are also passed.
+
+Now follow these steps if you want to (re-)start slurk.
+
+1. Navigate into the directory of your ``docker-compose.yml`` file.
+
+2. Stop old containers and remove containers, networks, volumes and images created by ``up``.
+
+.. code-block:: bash
+
+  $ docker-compose down
+
+3. Pull all associated docker images.
+
+.. code-block:: bash
+
+  $ docker-compose pull
+   
+
+4. (Optional) If you do not wish to use the default slurk from GitHub, you should manually build a slurk image of your preferred version afterwards. Start by navigating into your slurk project folder.
+
+.. code-block:: bash
+
+  $ docker build --tag "slurk/server" -f Dockerfile .
+
+Navigate back to the directory of your ``docker-compose.yml`` file afterwards.
+
+5. Start all specified containers in the background and leave them running.
+
+.. code-block:: bash
+
+  $ docker-compose up -d
+
+6. (Optional) Verify that all containers have been successfully started.
+
+.. code-block:: bash
+
+  $ docker container ls -a
+

--- a/docs/slurk_deployment.rst
+++ b/docs/slurk_deployment.rst
@@ -128,7 +128,7 @@ Now follow these steps if you want to (re-)start slurk.
   $ docker-compose pull
    
 
-4. (Optional) If you do not wish to use the default slurk from GitHub, you should manually build a slurk image of your preferred version afterwards. Start by navigating into your slurk project folder.
+4. (Optional) If you do not wish to use the default slurk from GitHub, you should manually build a slurk image of your preferred version. Start by navigating into your slurk project folder.
 
 .. code-block:: bash
 

--- a/docs/slurk_prerequisites.rst
+++ b/docs/slurk_prerequisites.rst
@@ -170,7 +170,13 @@ Checkout slurk
 Run with docker (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. Start the server:
+1. Go into the slurk top directory. Build your slurk docker image:
+
+.. code-block:: bash
+
+    docker build --tag "slurk/server" -f Dockerfile .
+
+2. Start the server:
 
 .. code-block:: bash
 
@@ -178,14 +184,14 @@ Run with docker (recommended)
     $ scripts/start_server.sh
     0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
-2. Fetch the admin token:
+3. Fetch the admin token:
 
 .. code-block:: bash
 
     $ scripts/read_admin_token.sh
     01234567-89ab-cdef-0123-456789abcdef
 
-3. (Optional) In case the output of the above script is empty, you may find valuable information in the logs:
+4. (Optional) In case the output of the above script is empty, you may find valuable information in the logs:
 
 .. code-block:: bash
 


### PR DESCRIPTION
r? @janagoetze Let's not pretend that we are the only ones who would have to ask how to do that.

Also some addition in docs/slurk_prerequisites.rst, to manually build the slurk image. For people who do not yet have a slurk image the result would be the same, no matter whether the image is pulled from GitHub or they built it themselves from the newly cloned slurk repo. But for people that already had a slurk image like Saskia, this may avoid confusion.