### PR TITLE
Make room for bot tokens optional

### DIFF
--- a/slurk/models/token.py
+++ b/slurk/models/token.py
@@ -27,8 +27,6 @@ class Token(Common):
     users = relationship("User", backref="token")
 
     def add_user(self, db_session):
-        if self.room is None:
-            raise ValueError("Token does not have a room associated")
         if self.registrations_left == 0:
             raise ValueError("No registrations left for given token")
         if self.registrations_left > 0:

--- a/slurk/views/api/users.py
+++ b/slurk/views/api/users.py
@@ -67,8 +67,9 @@ class Users(MethodView):
             )
 
         user = UserSchema().post(item)
-        user.rooms = [token.room]
-        db.commit()
+        if token.room is not None:
+            user.rooms = [token.room]
+            db.commit()
         return user
 
 

--- a/slurk/views/chat/__init__.py
+++ b/slurk/views/chat/__init__.py
@@ -20,6 +20,8 @@ def index():
     if current_user.rooms.count() == 0:
         if current_user.token.registrations_left == 0:
             return login_manager.unauthorized()
+        elif current_user.token.room is None:
+            return login_manager.unauthorized()
         else:
             current_user.rooms.append(current_user.token.room)
             db.commit()

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -154,15 +154,6 @@ class TestPostInvalid:
         )
         response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, parse_error(response)
 
-    def test_token_no_assigned_room(self, client, admin_token):
-        response = client.post(
-            "/slurk/api/users",
-            json={"name": "Another Test User", "token_id": admin_token},
-        )
-        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, parse_error(
-            response
-        )
-
     def test_unauthorized_access(self, client, tokens):
         response = client.post(
             "/slurk/api/users",
@@ -397,16 +388,6 @@ class TestPatchInvalid(UsersTable, InvalidWithEtagTemplate):
             headers={"If-Match": users.headers["ETag"]},
         )
         response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, parse_error(response)
-
-    def test_token_no_assigned_room(self, client, users, admin_token):
-        response = client.patch(
-            f'/slurk/api/users/{users.json["id"]}',
-            json={"name": "Another Test User", "token_id": admin_token},
-            headers={"If-Match": users.headers["ETag"]},
-        )
-        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, parse_error(
-            response
-        )
 
 
 @pytest.mark.depends(


### PR DESCRIPTION
Partially revert https://github.com/clp-research/slurk/pull/151/commits/fcf01535bd7dc979041605801350170e119338ed
Tokens without a room still can't be used to login via the login interface (and create a user in this way), but a request can now be used to create a user from a token without a room. The advantage is, that bots waiting to join any newly created task rooms, can remain without room until they are needed. It is no longer necessary for a bot to handle events received from a room that is no task room.