### PR TITLE
Intercept all messages

### DIFF
--- a/slurk/models/log.py
+++ b/slurk/models/log.py
@@ -24,11 +24,11 @@ class Log(Common):
         if event == "join":
             current_app.logger.info(f"{user.name} joined {room.layout.title}")
         if event == "leave":
-            current_app.logger.info(f"{user.name} left {room.layout.title})")
+            current_app.logger.info(f"{user.name} left {room.layout.title}")
         if event == "connect":
             current_app.logger.info(f"{user.name} connected")
         if event == "disconnect":
-            current_app.logger.info(f"{user.name} disconnected")
+            current_app.logger.info(f"{user.name} disconnected from {user.rooms}")
 
         log = Log(event=event, user=user, room=room, data=data, receiver=receiver)
 

--- a/slurk/views/chat/events.py
+++ b/slurk/views/chat/events.py
@@ -183,12 +183,18 @@ def emit_message(event, payload, data):
             target = str(room.id)
             private = False
 
-    user = dict(id=current_user.get_id(), name=current_user.name)
+    sender = dict(id=current_user.get_id(), name=current_user.name)
+    impersonate = payload.get("impersonate")
+    if impersonate:
+        # only impersonate someone who is in the room
+        for user in room.users:
+            if user.id == impersonate:
+                sender = dict(id=user.id, name=user.name)
 
     socketio.emit(
         event,
         dict(
-            user=user,
+            user=sender,
             room=room.id if room else None,
             timestamp=str(datetime.utcnow()),
             private=private,
@@ -207,7 +213,8 @@ def emit_message(event, payload, data):
     )
 
     for room in current_user.rooms:
-        socketio.emit("stop_typing", {"user": user}, room=str(room.id))
+        # TODO: decide whether impersonator (sender) or current_user should emit this
+        socketio.emit("stop_typing", {"user": sender}, room=str(room.id))
 
     return True
 

--- a/slurk/views/static/plugins/send-intercepted-message.js
+++ b/slurk/views/static/plugins/send-intercepted-message.js
@@ -1,0 +1,2 @@
+submit_command(text);
+display_message(current_user, current_timestamp, text, true);


### PR DESCRIPTION
Changes to enable Intervention Bot

The Intervention Bot is an example of an invisible participant that intercepts all messages to modify them in some way and send them on to the other users. No user knows that this is happening, the sender is shown as the original author.

- make it possible to impersonate another user when sending messages
- add a plugin send-intercepted-message that treats all messages as commands that then can be intercepted by a bot (no special syntax required, user doesn't know that the messages are not sent 1:1)