### PR TITLE
Integrate placeholder for typing-users plugin into chat layout

### DIFF
--- a/slurk/views/static/css/chat.css
+++ b/slurk/views/static/css/chat.css
@@ -99,8 +99,7 @@ header video {
 }
 
 #chat-area {
-    padding: 0 0 50px;
-    margin: 10px 0 15px;
+    margin: 10px 0 0px;
 }
 #chat-area li {
     padding: 0.5rem;
@@ -214,6 +213,17 @@ time:before{
     margin-left:auto;
     margin-right:0;
     font-size: 11px;
+}
+
+#typing {
+    margin: 0px 0px 15px;
+}
+
+#typing li {
+    padding: 0.5rem;
+    overflow: hidden;
+    display: flex;
+    opacity: 0.7;
 }
 
 #type-area input {

--- a/slurk/views/static/css/loadingdots.css
+++ b/slurk/views/static/css/loadingdots.css
@@ -1,0 +1,70 @@
+@charset "UTF-8";
+/**
+ *
+ * three-dots.css v0.1.0
+ *
+ * https://nzbin.github.io/three-dots/
+ *
+ * Copyright (c) 2018 nzbin
+ *
+ * Released under the MIT license
+ *
+ */
+
+/**
+ * ==============================================
+ * Dot Flashing
+ * ==============================================
+ */
+
+.dot-flashing {
+  display: inline-block;
+  margin: 0px 15px;
+  position: relative;
+  width: 10px;
+  height: 10px;
+  border-radius: 5px;
+  background-color: #4d4d4d;
+  color: #4d4d4d;
+  animation: dotFlashing 1s infinite linear alternate;
+  animation-delay: .5s;
+}
+
+.dot-flashing::before, .dot-flashing::after {
+  content: '';
+  display: inline-block;
+  position: absolute;
+  top: 0;
+}
+
+.dot-flashing::before {
+  left: -15px;
+  width: 10px;
+  height: 10px;
+  border-radius: 5px;
+  background-color: #4d4d4d;
+  color: #4d4d4d;
+  animation: dotFlashing 1s infinite alternate;
+  animation-delay: 0s;
+}
+
+.dot-flashing::after {
+  left: 15px;
+  width: 10px;
+  height: 10px;
+  border-radius: 5px;
+  background-color: #4d4d4d;
+  color: #4d4d4d;
+  animation: dotFlashing 1s infinite alternate;
+  animation-delay: 1s;
+}
+
+@keyframes dotFlashing {
+  0% {
+    background-color: #4d4d4d;
+  }
+  50%,
+  100% {
+    background-color: #cccccc;
+  }
+}

--- a/slurk/views/static/js/text.js
+++ b/slurk/views/static/js/text.js
@@ -53,7 +53,7 @@ $(document).ready(() => {
     window.setInterval(function () {
         if (is_typing !== -1)
             is_typing += 1;
-        if (is_typing === 5) {
+        if (is_typing === 3) {
             socket.emit("keypress", { "typing": false });
             is_typing = -1;
 	}

--- a/slurk/views/static/js/text.js
+++ b/slurk/views/static/js/text.js
@@ -53,7 +53,7 @@ $(document).ready(() => {
     window.setInterval(function () {
         if (is_typing !== -1)
             is_typing += 1;
-        if (is_typing === 3) {
+        if (is_typing === 5) {
             socket.emit("keypress", { "typing": false });
             is_typing = -1;
 	}

--- a/slurk/views/static/plugins/typing-users.js
+++ b/slurk/views/static/plugins/typing-users.js
@@ -1,5 +1,4 @@
 let typing_users = Object.values(users);
-
 let info_text = $(
     "<li class='other'>" +
     "  <div class='message-box'>" +
@@ -8,6 +7,12 @@ let info_text = $(
     "  </div>" +
     "</li>");
 
+
+let scrollbar_at_bottom = false;
+let content = $('#content');
+if (content.prop("scrollTop") + content.prop("clientHeight") + 20 >= content.prop("scrollHeight")) {
+    scrollbar_at_bottom = true;
+}
 
 if (typing_users.length === 0) {
     $("#typing").text("");
@@ -20,8 +25,10 @@ if (typing_users.length === 0) {
         info_text.find(".message").html("<em>" + typing_users.join("</em>, <em>") + "</em> are typing ...");
     }
     $("#typing").html(info_text);
+}
 
-    let content = $('#content');
+// only scroll down, if user not looking through older history
+if (scrollbar_at_bottom) {
     content.animate({ scrollTop: content.prop("scrollHeight") }, 0);
 }
 

--- a/slurk/views/static/plugins/typing-users.js
+++ b/slurk/views/static/plugins/typing-users.js
@@ -1,11 +1,27 @@
 let typing_users = Object.values(users);
 
+let info_text = $(
+    "<li class='other'>" +
+    "  <div class='message-box'>" +
+    "    <div class='dot-flashing'></div>" +
+    "    <span class='message'></span>" +
+    "  </div>" +
+    "</li>");
+
+
 if (typing_users.length === 0) {
     $("#typing").text("");
-} else if (typing_users.length === 1) {
-    $("#typing").html("<em>" + typing_users[0] + "</em> is typing ...");
-} else if (typing_users.length === 2) {
-    $("#typing").html("<em>" + typing_users.join("</em> and <em>") + "</em> are typing ...");
 } else {
-    $("#typing").html("<em>" + typing_users.join("</em>, <em>") + "</em> are typing ...");
+    if (typing_users.length === 1) {
+        info_text.find(".message").html("<em>" + typing_users[0] + "</em> is typing ...");
+    } else if (typing_users.length === 2) {
+        info_text.find(".message").html("<em>" + typing_users.join("</em> and <em>") + "</em> are typing ...");
+    } else {
+        info_text.find(".message").html("<em>" + typing_users.join("</em>, <em>") + "</em> are typing ...");
+    }
+    $("#typing").html(info_text);
+
+    let content = $('#content');
+    content.animate({ scrollTop: content.prop("scrollHeight") }, 0);
 }
+

--- a/slurk/views/templates/chat.html
+++ b/slurk/views/templates/chat.html
@@ -9,6 +9,7 @@
         href="{{ url_for('static', filename='3rd_party/font-awesome-4.7.0/css/font-awesome.min.css') }}" />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/global.css') }}" />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/chat.css') }}" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/loadingdots.css') }}" />
 
     <script type="text/javascript" src="{{ url_for('static', filename='js/3rd_party/jquery-3.6.0.min.js') }}"></script>
     <script type="text/javascript"
@@ -40,6 +41,7 @@
     </div>
     <div id="content">
         <div id="chat-area" class="fade"></div>
+	<div id="typing"></div>
     </div>
     <div id="type-area" style="display: none;">
         <input id="text" size="80" placeholder="Enter your message here!" readonly="readonly"><br><br>


### PR DESCRIPTION
Move the placeholder for typing-users from the display area to the chat area. It should now be more visibile to the participant. Additionally, researchers are no longer required (nor allowed) to insert a designated element into the custom display area. Passing the typing-users plugin suffices.

<img src="https://user-images.githubusercontent.com/66587202/148622406-7f0ca2f3-f0d0-4ebf-8222-c61ce09756df.gif" width="800" />
