### PR TITLE
safari-friendly date format

### DIFF
--- a/slurk/views/static/js/plugins.js
+++ b/slurk/views/static/js/plugins.js
@@ -7,7 +7,7 @@ function _append(text) {
 function _getTime(timestamp) {
     let currentDate = undefined
     if (typeof timestamp === "string") {
-        currentDate = new Date(timestamp)
+        currentDate = new Date(timestamp.replace(" ", "T"))
         currentDate.setTime(currentDate.getTime() - new Date().getTimezoneOffset() * 60000)
     } else if (timestamp === null) {
         currentDate = new Date()


### PR DESCRIPTION
Timestamps are now modified so that safari will parse them correctly fixing the NaN problem in the chat.
This solution still works with firefox and chromium