### PR TITLE
Collapsible instructions

### DIFF
--- a/docs/slurk_layouts.rst
+++ b/docs/slurk_layouts.rst
@@ -151,6 +151,7 @@ Injected as a script file into the site
 Examples:
   - ``"ask-reload"``: A pop-up asks on page reload if this is the desired action
   - ``"enforce-fullscreen"``: Page content is grayed out, until a button is clicked that sends user into fullscreen. See ``enforce-fullscreen_layout.json`` in ``examples`` for an example layout
+  - ``"collapsible-task-instructions"``: Hides and shows text on user clicks. This is useful for hiding lengthy task instructions until the user clicks on them on demand. See ``collapsible-instructions_layout.json`` in ``examples`` for an example layout.
   - ``"bounding-boxes"``: Makes it possible for users to draw rectangles inside a designated drawing area (html element with the id ``drawing-area``). Per default, drawn rectangles are not shared between users inside a room. If you wish for all users in a room to share a common canvas give all users inside the room the permission ``receive_bounding_box``
   - ``"mouse-tracking"``: Mouse movement and clicks inside the designated html element with the id ``tracking-area`` are registered. They can be handled by bots through the ``mouse`` event.
   - ``"live-typing"``: Chat partners receive a preview of messages that are currently being typed. Typed messages can't be edited in this mode. If a user started a message and stopped typing for 3sec, it is automatically submitted.

--- a/examples/collapsible-instructions_layout.json
+++ b/examples/collapsible-instructions_layout.json
@@ -2,9 +2,9 @@
   "title": "Example Layout - Collapsible Task Instructions",
   "html": [
     {
-        "layout-type": "div",
-        "class": "card",
-        "layout-content": [
+      "layout-type": "div",
+      "class": "card",
+      "layout-content": [
         {
           "layout-type": "button",
           "class": "collapsible",
@@ -29,27 +29,27 @@
               "style": "padding-bottom: 5px",
               "layout-content": "It requires 2 elements: a button of class collapsible, and an immediately neighboring element of class collapsible-content."
             },
-              {
-                  "layout-type": "p",
-                  "style": "padding-bottom: 5px",
-                  "layout-content": "Clicking the button repeatedly hides and shows the content."
-              }
+            {
+              "layout-type": "p",
+              "style": "padding-bottom: 5px",
+              "layout-content": "Clicking the button repeatedly hides and shows the content."
+            }
           ]
         }
       ]
     }
   ],
   "css": {
-      ".card": {
-          "position": "relative",
-          "background-color": "#fff",
-          "background-clip": "border-box",
-          "border": "1px solid rgba(0,0,0,.125)",
-          "border-radius": ".25rem",
-          "height": "100%",
-          "margin": "10px",
-          "padding": "15px"
-      },
+    ".card": {
+      "position": "relative",
+      "background-color": "#fff",
+      "background-clip": "border-box",
+      "border": "1px solid rgba(0,0,0,.125)",
+      "border-radius": ".25rem",
+      "height": "100%",
+      "margin": "10px",
+      "padding": "15px"
+    },
     ".collapsible": {
       "background-color": "#eee",
       "color": "#444",

--- a/examples/collapsible-instructions_layout.json
+++ b/examples/collapsible-instructions_layout.json
@@ -1,0 +1,74 @@
+{
+  "title": "Example Layout - Collapsible Task Instructions",
+  "html": [
+    {
+        "layout-type": "div",
+        "class": "card",
+        "layout-content": [
+        {
+          "layout-type": "button",
+          "class": "collapsible",
+          "layout-content": "Click to see task instructions"
+        },
+        {
+          "layout-type": "div",
+          "class": "collapsible-content",
+          "layout-content": [
+            {
+              "layout-type": "p",
+              "style": "padding-bottom: 5px",
+              "layout-content": "Hiding the task instructions in here."
+            },
+            {
+              "layout-type": "p",
+              "style": "padding-bottom: 5px",
+              "layout-content": "This type of box can also be used for other things in the display area."
+            },
+            {
+              "layout-type": "p",
+              "style": "padding-bottom: 5px",
+              "layout-content": "It requires 2 elements: a button of class collapsible, and an immediately neighboring element of class collapsible-content."
+            },
+              {
+                  "layout-type": "p",
+                  "style": "padding-bottom: 5px",
+                  "layout-content": "Clicking the button repeatedly hides and shows the content."
+              }
+          ]
+        }
+      ]
+    }
+  ],
+  "css": {
+      ".card": {
+          "position": "relative",
+          "background-color": "#fff",
+          "background-clip": "border-box",
+          "border": "1px solid rgba(0,0,0,.125)",
+          "border-radius": ".25rem",
+          "height": "100%",
+          "margin": "10px",
+          "padding": "15px"
+      },
+    ".collapsible": {
+      "background-color": "#eee",
+      "color": "#444",
+      "font-size": "18px",
+      "cursor": "pointer",
+      "padding": "18px",
+      "width": "100%",
+      "border": "none",
+      "text-align": "left",
+      "outline": "none"
+    },
+    ".collapsible-content": {
+      "padding": "18px 18px",
+      "display": "none",
+      "overflow": "hidden",
+      "background-color": "#f1f1f1"
+    }
+  },
+  "scripts": {
+    "plain": "collapsible-task-instructions"
+  }
+}

--- a/slurk/views/static/plugins/collapsible-task-instructions.js
+++ b/slurk/views/static/plugins/collapsible-task-instructions.js
@@ -1,0 +1,16 @@
+// https://www.w3schools.com/howto/howto_js_collapsible.asp
+
+var coll = document.getElementsByClassName("collapsible");
+var i;
+
+for (i = 0; i < coll.length; i++) {
+  coll[i].addEventListener("click", function() {
+    this.classList.toggle("active");
+    var content = this.nextElementSibling;
+    if (content.style.display === "block") {
+      content.style.display = "none";
+    } else {
+      content.style.display = "block";
+    }
+  });
+}


### PR DESCRIPTION
- add a JavaScript plugin that allows to create boxes of text (or other content) that can be shown and hidden by clicking on them
- the current use case for this is task instructions that may take up a lot of space in the main display/game area of the browser -> the user can just hide them away and show them when needed


![slurk-collapsible](https://user-images.githubusercontent.com/54643151/233940027-7e7495d4-28ba-4ab6-9e4b-4e15e340b602.gif)
