### PR TITLE
Update socketio events to new version (=> 5.8 of python socketio package)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ WTForms==2.3
 six
 gevent-websocket
 gunicorn
-python-socketio==5.7.2

--- a/slurk/views/chat/events.py
+++ b/slurk/views/chat/events.py
@@ -20,7 +20,7 @@ def room_created(payload):
     if "task" in payload and task is None:
         return False, f'Task "{task}" does not exist'
 
-    socketio.emit("new_room", {"room": room.id}, broadcast=True)
+    socketio.emit("new_room", {"room": room.id})
 
     if task is not None:
         users = []
@@ -30,7 +30,6 @@ def room_created(payload):
         socketio.emit(
             "new_task_room",
             {"room": room.id, "task": task.id, "users": users},
-            broadcast=True,
         )
     return True
 
@@ -209,6 +208,12 @@ def emit_message(event, payload, data):
             if user.id == impersonate:
                 sender = dict(id=user.id, name=user.name)
 
+    extra_args = {
+        "room": target
+    }
+    if broadcast:
+        extra_args.pop("room")
+
     socketio.emit(
         event,
         dict(
@@ -218,8 +223,7 @@ def emit_message(event, payload, data):
             private=private,
             **data,
         ),
-        room=target,
-        broadcast=broadcast,
+        **extra_args
     )
 
     Log.add(

--- a/slurk/views/chat/events.py
+++ b/slurk/views/chat/events.py
@@ -208,9 +208,7 @@ def emit_message(event, payload, data):
             if user.id == impersonate:
                 sender = dict(id=user.id, name=user.name)
 
-    extra_args = {
-        "room": target
-    }
+    extra_args = {"room": target}
     if broadcast:
         extra_args.pop("room")
 
@@ -223,7 +221,7 @@ def emit_message(event, payload, data):
             private=private,
             **data,
         ),
-        **extra_args
+        **extra_args,
     )
 
     Log.add(

--- a/slurk/views/static/plugins/collapsible-task-instructions.js
+++ b/slurk/views/static/plugins/collapsible-task-instructions.js
@@ -1,11 +1,11 @@
 // https://www.w3schools.com/howto/howto_js_collapsible.asp
 
-var coll = document.getElementsByClassName("collapsible");
+let coll = document.getElementsByClassName("collapsible");
 
 for (let i=0; i<coll.length; i++) {
   coll[i].addEventListener("click", function() {
     this.classList.toggle("active");
-    var content = this.nextElementSibling;
+    let content = this.nextElementSibling;
     if (content.style.display === "block") {
       content.style.display = "none";
     } else {

--- a/slurk/views/static/plugins/collapsible-task-instructions.js
+++ b/slurk/views/static/plugins/collapsible-task-instructions.js
@@ -1,9 +1,8 @@
 // https://www.w3schools.com/howto/howto_js_collapsible.asp
 
 var coll = document.getElementsByClassName("collapsible");
-var i;
 
-for (i = 0; i < coll.length; i++) {
+for (let i=0; i<coll.length; i++) {
   coll[i].addEventListener("click", function() {
     this.classList.toggle("active");
     var content = this.nextElementSibling;


### PR DESCRIPTION
this pull requests updates the socket-io events to reflect changes made in python-socketio => 5.8 - broadcasting events is achieved by removing the `to` or `room` parameter from the keyword arguments of the `socketio.emit()` method.

This fixes [this issue](https://github.com/clp-research/slurk/issues/255)

additional changes: minor fix to the `collapsible.js` plugin (use scope defined variables instead of defining global ones)