### PR TITLE
include room id to the data being transmitted by start and stop typing events

### DIFF
--- a/slurk/views/chat/events.py
+++ b/slurk/views/chat/events.py
@@ -99,9 +99,13 @@ def keypress(message):
             "name": current_user.name,
         }
         if typing:
-            socketio.emit("start_typing", {"user": user, "room": str(room.id)}, room=str(room.id))
+            socketio.emit(
+                "start_typing", {"user": user, "room": str(room.id)}, room=str(room.id)
+            )
         else:
-            socketio.emit("stop_typing", {"user": user, "room": str(room.id)}, room=str(room.id))
+            socketio.emit(
+                "stop_typing", {"user": user, "room": str(room.id)}, room=str(room.id)
+            )
 
 
 @socketio.event
@@ -233,7 +237,9 @@ def emit_message(event, payload, data):
     )
 
     for room in current_user.rooms:
-        socketio.emit("stop_typing", {"user": sender, "room": str(room.id)}, room=str(room.id))
+        socketio.emit(
+            "stop_typing", {"user": sender, "room": str(room.id)}, room=str(room.id)
+        )
 
     return True
 

--- a/slurk/views/chat/events.py
+++ b/slurk/views/chat/events.py
@@ -99,9 +99,9 @@ def keypress(message):
             "name": current_user.name,
         }
         if typing:
-            socketio.emit("start_typing", {"user": user}, room=str(room.id))
+            socketio.emit("start_typing", {"user": user, "room": str(room.id)}, room=str(room.id))
         else:
-            socketio.emit("stop_typing", {"user": user}, room=str(room.id))
+            socketio.emit("stop_typing", {"user": user, "room": str(room.id)}, room=str(room.id))
 
 
 @socketio.event
@@ -233,7 +233,7 @@ def emit_message(event, payload, data):
     )
 
     for room in current_user.rooms:
-        socketio.emit("stop_typing", {"user": sender}, room=str(room.id))
+        socketio.emit("stop_typing", {"user": sender, "room": str(room.id)}, room=str(room.id))
 
     return True
 


### PR DESCRIPTION
include the room_id in the data being sent by the start and stop typing events so that bots can also receive these events and assign them to the respective room. This information can be logged to calculate writing and idling time of a user